### PR TITLE
feat: add podcast transcript and audio generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 reporadio
 .context
 bin
+reporadio-cli

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -1,0 +1,339 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// PodcastConfig represents the structure of a podcast.yml file
+type PodcastConfig struct {
+	Episodes []Episode `yaml:"episodes"`
+}
+
+// loadPodcastConfig loads a podcast configuration from .reporadio/<name>/podcast.yml
+func loadPodcastConfig(name string) (*PodcastConfig, error) {
+	configPath := filepath.Join(".reporadio", name, "podcast.yml")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read podcast config %s: %w", configPath, err)
+	}
+
+	var config PodcastConfig
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse podcast config %s: %w", configPath, err)
+	}
+
+	return &config, nil
+}
+
+// loadChatContext loads chat entries from .reporadio/<name>/chat.yaml
+func loadChatContext(podcastName string) ([]map[string]interface{}, error) {
+	chatPath := filepath.Join(".reporadio", podcastName, "chat.yaml")
+
+	if _, err := os.Stat(chatPath); os.IsNotExist(err) {
+		return []map[string]interface{}{}, nil
+	}
+
+	data, err := os.ReadFile(chatPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read chat context: %w", err)
+	}
+
+	var chatFile map[string]interface{}
+	err = yaml.Unmarshal(data, &chatFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse chat context: %w", err)
+	}
+
+	if entries, ok := chatFile["entries"].([]interface{}); ok {
+		result := make([]map[string]interface{}, len(entries))
+		for i, entry := range entries {
+			if entryMap, ok := entry.(map[string]interface{}); ok {
+				result[i] = entryMap
+			}
+		}
+		return result, nil
+	}
+
+	return []map[string]interface{}{}, nil
+}
+
+// appendToChatContext appends a new episode entry to the chat.yaml file
+func appendToChatContext(podcastName string, episodeNum int, title, transcript string) error {
+	chatPath := filepath.Join(".reporadio", podcastName, "chat.yaml")
+
+	// Create directory if it doesn't exist
+	err := os.MkdirAll(filepath.Dir(chatPath), 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create chat context directory: %w", err)
+	}
+
+	var chatFile map[string]interface{}
+
+	if data, err := os.ReadFile(chatPath); err == nil {
+		if err := yaml.Unmarshal(data, &chatFile); err != nil {
+			return fmt.Errorf("failed to parse existing chat context: %w", err)
+		}
+	} else {
+		chatFile = make(map[string]interface{})
+	}
+
+	timestamp := time.Now().Format("2006-01-02T15:04:05.000000-07:00")
+	newEntry := map[string]interface{}{
+		"timestamp": timestamp,
+		"role":      "assistant",
+		"message":   fmt.Sprintf("Episode %d: %s\n\n%s", episodeNum, title, transcript),
+		"step":      "episode",
+	}
+
+	if entries, ok := chatFile["entries"].([]interface{}); ok {
+		chatFile["entries"] = append(entries, newEntry)
+	} else {
+		chatFile["entries"] = []interface{}{newEntry}
+	}
+
+	data, err := yaml.Marshal(chatFile)
+	if err != nil {
+		return fmt.Errorf("failed to marshal chat context: %w", err)
+	}
+
+	return os.WriteFile(chatPath, data, 0644)
+}
+
+// generateEpisodeTranscript generates a transcript for a single episode
+func generateEpisodeTranscript(episode Episode, episodeNum int, outputDir string, client *openai.Client, chatEntries []map[string]interface{}) error {
+	Debug(nil, "Starting episode transcript generation")
+	Debugf(nil, "Episode %d: %s", episodeNum, episode.Title)
+
+	// Create output directory if it doesn't exist
+	err := os.MkdirAll(outputDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	Debugf(nil, "Created output directory: %s", outputDir)
+
+	// Resolve include paths using Scanner
+	scanner := NewScanner()
+	resolvedPaths, err := scanner.ResolveIncludePaths(episode.Include)
+	if err != nil {
+		return fmt.Errorf("failed to resolve include paths: %w", err)
+	}
+	Debugf(nil, "Resolved %d files from %d include paths", len(resolvedPaths), len(episode.Include))
+
+	// Read all resolved files
+	var fileContents strings.Builder
+	for _, filePath := range resolvedPaths {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to read file %s: %v\n", filePath, err)
+			continue
+		}
+
+		fileContents.WriteString(fmt.Sprintf("\n--- %s ---\n", filePath))
+		fileContents.WriteString(string(content))
+		fileContents.WriteString("\n")
+	}
+	Debugf(nil, "Read %d files successfully", len(resolvedPaths))
+
+	// If no client provided (for testing), just create a placeholder file
+	if client == nil {
+		transcriptPath := filepath.Join(outputDir, fmt.Sprintf("ep%d.md", episodeNum))
+		placeholderContent := fmt.Sprintf("# %s\n\nPlaceholder transcript for testing", episode.Title)
+		return os.WriteFile(transcriptPath, []byte(placeholderContent), 0644)
+	}
+
+	// Build context from previous episodes
+	var contextBuilder strings.Builder
+	if len(chatEntries) > 0 {
+		contextBuilder.WriteString("\n--- Previous Episodes Context ---\n")
+		for _, entry := range chatEntries {
+			if role, ok := entry["role"].(string); ok && role == "assistant" {
+				if step, ok := entry["step"].(string); ok && step == "episode" {
+					if message, ok := entry["message"].(string); ok {
+						contextBuilder.WriteString(message)
+						contextBuilder.WriteString("\n")
+					}
+				}
+			}
+		}
+	}
+	Debugf(nil, "Built context from %d chat entries", len(chatEntries))
+
+	// Create the prompt using the template system
+	Debug(nil, "Creating prompt from template")
+	promptManager, err := NewPromptManager()
+	if err != nil {
+		return fmt.Errorf("failed to create prompt manager: %w", err)
+	}
+
+	templateData := struct {
+		Title        string
+		Description  string
+		Instructions string
+		Voicing      string
+		Context      string
+		FileContents string
+	}{
+		Title:        episode.Title,
+		Description:  episode.Description,
+		Instructions: episode.Instructions,
+		Voicing:      episode.Voicing,
+		Context:      contextBuilder.String(),
+		FileContents: fileContents.String(),
+	}
+
+	prompt, err := promptManager.Execute("episode_transcript.tmpl", templateData)
+	if err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	Debug(nil, "Prompt created successfully")
+
+	// Create chat completion request
+	messages := []openai.ChatCompletionMessage{
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: prompt,
+		},
+	}
+
+	// Get response from OpenAI
+	Debug(nil, "Generating transcript with OpenAI")
+	transcript, err := getChatResponse(client, messages)
+	if err != nil {
+		return fmt.Errorf("failed to generate transcript: %w", err)
+	}
+	Debugf(nil, "Generated transcript with %d characters", len(transcript))
+
+	// Write transcript to file
+	transcriptPath := filepath.Join(outputDir, fmt.Sprintf("ep%d.md", episodeNum))
+	err = os.WriteFile(transcriptPath, []byte(transcript), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write transcript file: %w", err)
+	}
+	Debugf(nil, "Saved transcript to: %s", transcriptPath)
+
+	Debug(nil, "Episode transcript generation complete")
+	return nil
+}
+
+// generatePodcastTranscripts generates transcripts and optionally audio for all episodes in a podcast config
+func generatePodcastTranscripts(podcastName string, config *PodcastConfig, client *openai.Client, generateAudio bool) error {
+	Debug(nil, "Starting podcast transcript generation")
+	Debugf(nil, "Podcast: %s, Episodes: %d, Audio: %t", podcastName, len(config.Episodes), generateAudio)
+
+	outputDir := filepath.Join(".reporadio", podcastName, "episodes")
+
+	// Load existing chat context
+	Debug(nil, "Loading chat context")
+	chatEntries, err := loadChatContext(podcastName)
+	if err != nil {
+		return fmt.Errorf("failed to load chat context: %w", err)
+	}
+	Debugf(nil, "Loaded %d chat entries", len(chatEntries))
+
+	fmt.Printf("Generating transcripts for %d episodes...\n", len(config.Episodes))
+	if generateAudio {
+		fmt.Printf("Audio generation enabled\n")
+	}
+
+	for i, episode := range config.Episodes {
+		episodeNum := i + 1
+		fmt.Printf("Generating Episode %d: %s\n", episodeNum, episode.Title)
+
+		err := generateEpisodeTranscript(episode, episodeNum, outputDir, client, chatEntries)
+		if err != nil {
+			return fmt.Errorf("failed to generate episode %d: %w", episodeNum, err)
+		}
+
+		fmt.Printf("✓ Generated ep%d.md\n", episodeNum)
+
+		// Read generated transcript and append to chat context
+		transcriptPath := filepath.Join(outputDir, fmt.Sprintf("ep%d.md", episodeNum))
+		transcriptContent, err := os.ReadFile(transcriptPath)
+		if err != nil {
+			return fmt.Errorf("failed to read generated transcript: %w", err)
+		}
+
+		Debug(nil, "Appending to chat context")
+		err = appendToChatContext(podcastName, episodeNum, episode.Title, string(transcriptContent))
+		if err != nil {
+			return fmt.Errorf("failed to append to chat context: %w", err)
+		}
+
+		// Generate audio if requested and client is available
+		if generateAudio && client != nil {
+			fmt.Printf("Generating audio for Episode %d...\n", episodeNum)
+			Debug(nil, "Starting audio generation")
+
+			audioPath := filepath.Join(outputDir, fmt.Sprintf("ep%d.mp3", episodeNum))
+
+			err = generateEpisodeAudio(transcriptPath, audioPath, client)
+			if err != nil {
+				return fmt.Errorf("failed to generate audio for episode %d: %w", episodeNum, err)
+			}
+
+			fmt.Printf("✓ Generated ep%d.mp3\n", episodeNum)
+		}
+	}
+
+	fmt.Printf("\nAll transcripts generated in %s\n", outputDir)
+	if generateAudio {
+		fmt.Printf("All audio files generated in %s\n", outputDir)
+	}
+	Debug(nil, "Podcast transcript generation complete")
+	return nil
+}
+
+var generateCmd = &cobra.Command{
+	Use:   "generate [podcast-name]",
+	Short: "Generate a specific podcast",
+	Long:  `The generate command generates the transcript and audio based on the podcast config.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE:  runGenerate,
+}
+
+func runGenerate(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		// TODO: List available podcast configs
+		return fmt.Errorf("please specify a podcast name")
+	}
+
+	podcastName := args[0]
+
+	// Load podcast config
+	config, err := loadPodcastConfig(podcastName)
+	if err != nil {
+		return err
+	}
+
+	// Get flags
+	generateAudio, _ := cmd.Flags().GetBool("audio")
+
+	// Get OpenAI API key from environment variable
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		return fmt.Errorf("please set the OPENAI_API_KEY environment variable")
+	}
+
+	// Create OpenAI client
+	client := openai.NewClient(apiKey)
+
+	// Generate transcripts (and optionally audio) for all episodes
+	return generatePodcastTranscripts(podcastName, config, client, generateAudio)
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+
+	// Add flags for the generate command
+	generateCmd.Flags().Bool("audio", false, "Generate audio files in addition to transcripts")
+}

--- a/internal/generate_scanner_test.go
+++ b/internal/generate_scanner_test.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateEpisodeWithScanner(t *testing.T) {
+	// Create temporary directory structure
+	tmpDir := t.TempDir()
+
+	// Create test files
+	if err := os.MkdirAll(filepath.Join(tmpDir, "src"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "src", "main.go"), []byte("package main\n\nfunc main() {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("# Test Project"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .gitignore
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "debug.log"), []byte("debug info"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create episode with mixed includes
+	episode := Episode{
+		Title:       "Test Episode",
+		Description: "Test description",
+		Include: []string{
+			filepath.Join(tmpDir, "README.md"),       // individual file
+			filepath.Join(tmpDir, "src"),             // directory (should expand)
+			filepath.Join(tmpDir, "debug.log"),       // gitignored file (should include)
+			filepath.Join(tmpDir, "nonexistent.txt"), // missing file (should warn and skip)
+		},
+	}
+
+	outputDir := filepath.Join(tmpDir, "output")
+
+	// Generate episode transcript (without OpenAI client, so it creates placeholder)
+	err := generateEpisodeTranscript(episode, 1, outputDir, nil, nil)
+	if err != nil {
+		t.Fatalf("generateEpisodeTranscript failed: %v", err)
+	}
+
+	// Check that transcript file was created
+	transcriptPath := filepath.Join(outputDir, "ep1.md")
+	if _, err := os.Stat(transcriptPath); err != nil {
+		t.Fatalf("Transcript file not created: %v", err)
+	}
+
+	// Read transcript content
+	content, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		t.Fatalf("Failed to read transcript: %v", err)
+	}
+
+	transcriptContent := string(content)
+
+	// Should contain episode title
+	if !strings.Contains(transcriptContent, "Test Episode") {
+		t.Error("Transcript should contain episode title")
+	}
+}

--- a/internal/generate_test.go
+++ b/internal/generate_test.go
@@ -1,0 +1,294 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadPodcastConfig(t *testing.T) {
+	// Create a temporary podcast config for testing
+	tempDir := t.TempDir()
+	podcastDir := filepath.Join(tempDir, ".reporadio", "test")
+	err := os.MkdirAll(podcastDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	configContent := `episodes:
+  - title: 'Episode 1: Test Episode'
+    description: 'A test episode'
+    instructions: 'Test instructions'
+    voicing: 'Test voicing'
+    include:
+      - README.md
+      - main.go
+`
+
+	configPath := filepath.Join(podcastDir, "podcast.yml")
+	err = os.WriteFile(configPath, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test config: %v", err)
+	}
+
+	// Change to temp directory to simulate running from project root
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Test loading the config
+	config, err := loadPodcastConfig("test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if len(config.Episodes) != 1 {
+		t.Fatalf("Expected 1 episode, got %d", len(config.Episodes))
+	}
+
+	episode := config.Episodes[0]
+	if episode.Title != "Episode 1: Test Episode" {
+		t.Errorf("Expected title 'Episode 1: Test Episode', got '%s'", episode.Title)
+	}
+
+	if len(episode.Include) != 2 {
+		t.Errorf("Expected 2 included files, got %d", len(episode.Include))
+	}
+}
+
+func TestLoadPodcastConfigNotFound(t *testing.T) {
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	_, err := loadPodcastConfig("nonexistent")
+	if err == nil {
+		t.Fatal("Expected error for nonexistent config, got nil")
+	}
+}
+
+func TestGenerateEpisodeTranscript(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Create test files that the episode will include
+	err := os.WriteFile("README.md", []byte("# Test Project\nThis is a test project."), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	err = os.WriteFile("main.go", []byte("package main\n\nfunc main() {\n\tprintln(\"Hello, World!\")\n}"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create test episode
+	episode := Episode{
+		Title:        "Episode 1: Introduction",
+		Description:  "An introduction to the project",
+		Instructions: "Explain the project basics",
+		Voicing:      "Friendly and informative",
+		Include:      []string{"README.md", "main.go"},
+	}
+
+	// Create a mock OpenAI client (we'll use nil for now and handle it in the function)
+	outputDir := filepath.Join(".reporadio", "test", "episodes")
+
+	// Test the function
+	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{})
+
+	// For now, we expect this to fail since we don't have a real client
+	// but we want to test the file reading and structure logic
+	if err == nil {
+		// Check if transcript file was created
+		transcriptPath := filepath.Join(outputDir, "ep1.md")
+		if _, err := os.Stat(transcriptPath); os.IsNotExist(err) {
+			t.Error("Expected transcript file to be created")
+		}
+	}
+}
+
+func TestGeneratePodcastTranscripts(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Create test files
+	err := os.WriteFile("README.md", []byte("# Test Project\nThis is a test project."), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	err = os.WriteFile("main.go", []byte("package main\n\nfunc main() {\n\tprintln(\"Hello, World!\")\n}"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create test podcast config
+	config := &PodcastConfig{
+		Episodes: []Episode{
+			{
+				Title:        "Episode 1: Introduction",
+				Description:  "An introduction to the project",
+				Instructions: "Explain the project basics",
+				Voicing:      "Friendly and informative",
+				Include:      []string{"README.md"},
+			},
+			{
+				Title:        "Episode 2: Code Overview",
+				Description:  "Overview of the main code",
+				Instructions: "Explain the code structure",
+				Voicing:      "Technical but accessible",
+				Include:      []string{"main.go"},
+			},
+		},
+	}
+
+	// Test the function (with nil client for testing)
+	err = generatePodcastTranscripts("test", config, nil, false)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Check if transcript files were created
+	outputDir := filepath.Join(".reporadio", "test", "episodes")
+
+	ep1Path := filepath.Join(outputDir, "ep1.md")
+	if _, err := os.Stat(ep1Path); os.IsNotExist(err) {
+		t.Error("Expected ep1.md to be created")
+	}
+
+	ep2Path := filepath.Join(outputDir, "ep2.md")
+	if _, err := os.Stat(ep2Path); os.IsNotExist(err) {
+		t.Error("Expected ep2.md to be created")
+	}
+
+	// Check content of first episode
+	content, err := os.ReadFile(ep1Path)
+	if err != nil {
+		t.Fatalf("Failed to read ep1.md: %v", err)
+	}
+
+	if !strings.Contains(string(content), "Episode 1: Introduction") {
+		t.Error("Episode 1 transcript should contain the title")
+	}
+}
+
+func TestGeneratePodcastTranscriptsWithAudio(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	defer func() { _ = os.Chdir(oldWd) }() // Ignore error in test cleanup
+	_ = os.Chdir(tempDir)
+
+	// Create test files
+	err := os.WriteFile("README.md", []byte("# Test Project\nThis is a test project."), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create test podcast config
+	config := &PodcastConfig{
+		Episodes: []Episode{
+			{
+				Title:        "Episode 1: Introduction",
+				Description:  "A short intro episode",
+				Instructions: "Keep it brief",
+				Voicing:      "Friendly",
+				Include:      []string{"README.md"},
+			},
+		},
+	}
+
+	// Test with audio generation but no client (should handle gracefully)
+	err = generatePodcastTranscripts("test", config, nil, true)
+	if err != nil {
+		t.Fatalf("Expected no error with nil client, got %v", err)
+	}
+
+	// Check if transcript was created
+	outputDir := filepath.Join(".reporadio", "test", "episodes")
+	ep1Path := filepath.Join(outputDir, "ep1.md")
+	if _, err := os.Stat(ep1Path); os.IsNotExist(err) {
+		t.Error("Expected ep1.md to be created")
+	}
+
+	// Audio file should not be created with nil client
+	audioPath := filepath.Join(outputDir, "ep1.mp3")
+	if _, err := os.Stat(audioPath); err == nil {
+		t.Error("Did not expect ep1.mp3 to be created with nil client")
+	}
+}
+
+func TestChatContext(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	podcastDir := filepath.Join(tempDir, ".reporadio", "test")
+	err := os.MkdirAll(podcastDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+
+	// Change to temp directory to simulate running from project root
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	os.Chdir(tempDir)
+
+	// Test loading empty chat context
+	entries, err := loadChatContext("test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("Expected 0 entries, got %d", len(entries))
+	}
+
+	// Test appending to chat context
+	err = appendToChatContext("test", 1, "Test Episode", "Test transcript content")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Test loading chat context with one entry
+	entries, err = loadChatContext("test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(entries))
+	}
+
+	// Verify the entry content
+	entry := entries[0]
+	if role, ok := entry["role"].(string); !ok || role != "assistant" {
+		t.Fatalf("Expected role 'assistant', got %v", entry["role"])
+	}
+	if step, ok := entry["step"].(string); !ok || step != "episode" {
+		t.Fatalf("Expected step 'episode', got %v", entry["step"])
+	}
+	if message, ok := entry["message"].(string); !ok || !strings.Contains(message, "Test Episode") {
+		t.Fatalf("Expected message to contain 'Test Episode', got %v", entry["message"])
+	}
+
+	// Test appending another entry
+	err = appendToChatContext("test", 2, "Second Episode", "Second transcript content")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Test loading chat context with two entries
+	entries, err = loadChatContext("test")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(entries))
+	}
+}

--- a/internal/tts.go
+++ b/internal/tts.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// convertTextToSpeech converts text to speech using OpenAI TTS
+func convertTextToSpeech(client *openai.Client, text string, filename string) error {
+	if client == nil {
+		return fmt.Errorf("OpenAI client is required for text-to-speech conversion")
+	}
+
+	// Create text-to-speech request
+	resp, err := client.CreateSpeech(context.Background(), openai.CreateSpeechRequest{
+		Model:          openai.TTSModelGPT4oMini,
+		Input:          text,
+		Voice:          openai.VoiceAlloy,
+		ResponseFormat: openai.SpeechResponseFormatMp3,
+		Speed:          1.0,
+	})
+
+	if err != nil {
+		return fmt.Errorf("error creating speech: %v", err)
+	}
+	defer func() { _ = resp.Close() }()
+
+	// Create output file
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("error creating output file: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	// Copy the audio data to file
+	_, err = io.Copy(file, resp)
+	if err != nil {
+		return fmt.Errorf("error writing audio data: %v", err)
+	}
+
+	return nil
+}
+
+// generateEpisodeAudio generates audio for a single episode transcript
+func generateEpisodeAudio(transcriptPath, audioPath string, client *openai.Client) error {
+	if client == nil {
+		return fmt.Errorf("OpenAI client is required for audio generation")
+	}
+
+	// Read transcript content
+	content, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		return fmt.Errorf("failed to read transcript %s: %w", transcriptPath, err)
+	}
+
+	// Convert text to speech
+	return convertTextToSpeech(client, string(content), audioPath)
+}

--- a/internal/tts_test.go
+++ b/internal/tts_test.go
@@ -1,0 +1,51 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateEpisodeAudio(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create a test transcript file
+	transcriptPath := filepath.Join(tempDir, "test_transcript.md")
+	transcriptContent := "# Test Episode\n\nThis is a short test transcript for audio generation."
+
+	err := os.WriteFile(transcriptPath, []byte(transcriptContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test transcript: %v", err)
+	}
+
+	audioPath := filepath.Join(tempDir, "test_audio.mp3")
+
+	// Test with nil client (should handle gracefully)
+	err = generateEpisodeAudio(transcriptPath, audioPath, nil)
+	if err == nil {
+		t.Error("Expected error with nil client")
+	}
+
+	// Check that no audio file was created
+	if _, err := os.Stat(audioPath); err == nil {
+		t.Error("Did not expect audio file to be created with nil client")
+	}
+}
+
+func TestConvertTextToSpeech(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	audioPath := filepath.Join(tempDir, "test_speech.mp3")
+
+	// Test with nil client (should handle gracefully)
+	err := convertTextToSpeech(nil, "Hello, world!", audioPath)
+	if err == nil {
+		t.Error("Expected error with nil client")
+	}
+
+	// Check that no audio file was created
+	if _, err := os.Stat(audioPath); err == nil {
+		t.Error("Did not expect audio file to be created with nil client")
+	}
+}


### PR DESCRIPTION
- Implemented functionality to generate podcast transcripts and audio using OpenAI's API.
- Added support for loading podcast configurations and chat contexts.
- Introduced a new command `generate` to create transcripts and optionally audio for specified podcasts.
- Developed tests for podcast configuration loading, transcript generation, and chat context management.
- Integrated text-to-speech conversion for generating audio files from transcripts.
- Updated `.gitignore` to include new CLI tool and output directories.

CLOSES: #8 
CLOSES: #14 
CLOSES: #5 
CLOSES: #13