### PR TITLE
fix: update podcast generation command to include audio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ reporadio create my-podcast
 ### Generate a podcast:
 
 ```bash
-reporadio generate my-podcast
+reporadio generate my-podcast --audio
 ```
 ---
 


### PR DESCRIPTION
The command for generating a podcast now includes the `--audio` option to ensure audio files are created.