### PR TITLE
fix: update installation and command instructions for reporadio-cli

### DIFF
--- a/.reporadio/welcome/podcast.yml
+++ b/.reporadio/welcome/podcast.yml
@@ -1,7 +1,7 @@
 episodes:
     - title: 'Understanding RepoRadio: Features Overview'
       description: Explore the core features of RepoRadio, including its CLI capabilities and potential for enhancing the developer onboarding experience.
-      instructions: Discuss how RepoRadio transforms code documentation into audio narratives. Highlight key features that make it valuable for developers.
+      instructions: Discuss how RepoRadio transforms code documentation into audio narratives. Highlight key features that make it valuable for developers. The reporadio cli executable is `reporadio-cli` once installed.
       voicing: informative and friendly
       include:
         - README.md

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ export OPENAI_API_KEY=sk-...
 ### 📦 Install via Go
 
 ```bash
-go install github.com/reporad-io/reporadio@latest
+go install github.com/reporadio/reporadio-cli@main
 ```
 
 Make sure `$GOPATH/bin` is in your `$PATH`.
@@ -47,13 +47,13 @@ Make sure `$GOPATH/bin` is in your `$PATH`.
 ### Create a new podcast:
 
 ```bash
-reporadio create my-podcast
+reporadio-cli create my-podcast
 ```
 
 ### Generate a podcast:
 
 ```bash
-reporadio generate my-podcast --audio
+reporadio-cli generate my-podcast --audio
 ```
 ---
 


### PR DESCRIPTION
Updated the installation command in README.md to reflect the correct repository path for reporadio-cli. Also, modified the podcast creation and generation commands to use `reporadio-cli` instead of `reporadio` for consistency and accuracy.