### PR TITLE
chore: update podcast configuration handling

### DIFF
--- a/internal/command_integration_test.go
+++ b/internal/command_integration_test.go
@@ -65,8 +65,18 @@ func TestGenerateEpisodeWithCommands(t *testing.T) {
 
 	outputDir := filepath.Join(tempDir, "output")
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// Test with nil client (placeholder mode)
-	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, "")
+	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, podcastConfig, "")
 	if err != nil {
 		t.Fatalf("Failed to generate episode transcript: %v", err)
 	}

--- a/internal/create_test.go
+++ b/internal/create_test.go
@@ -41,8 +41,8 @@ func TestCreateProjectStructure(t *testing.T) {
 		t.Error("Episodes directory was not created")
 	}
 
-	if _, err := os.Stat(".reporadio/test-podcast/episode.yaml"); os.IsNotExist(err) {
-		t.Error("Episode YAML file was not created")
+	if _, err := os.Stat(".reporadio/test-podcast/podcast.yml"); os.IsNotExist(err) {
+		t.Error("Podcast YAML file was not created")
 	}
 
 	if _, err := os.Stat(".reporadio/test-podcast/chat.yaml"); os.IsNotExist(err) {

--- a/internal/end_to_end_test.go
+++ b/internal/end_to_end_test.go
@@ -93,9 +93,19 @@ ls -la | head -5
 		t.Fatalf("Expected 6 commands, got %d", len(episode.Commands))
 	}
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// Generate the episode transcript
 	outputDir := filepath.Join(tempDir, "output")
-	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, "30s")
+	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, podcastConfig, "30s")
 	if err != nil {
 		t.Fatalf("Failed to generate episode transcript: %v", err)
 	}

--- a/internal/episode.go
+++ b/internal/episode.go
@@ -21,7 +21,7 @@ type Episode struct {
 	Include []string `json:"include" yaml:"include"`
 
 	// Commands contains optional shell commands to execute for dynamic content
-	Commands []string `json:"commands,omitempty" yaml:"commands,omitempty"`
+	Commands []string `json:"commands" yaml:"commands"`
 }
 
 // ToYAML converts episode to YAML bytes

--- a/internal/episode_integration_test.go
+++ b/internal/episode_integration_test.go
@@ -48,8 +48,18 @@ func TestGenerateEpisodeTranscriptWithCommands(t *testing.T) {
 
 	outputDir := filepath.Join(tempDir, "output")
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// Generate transcript with nil client (testing mode)
-	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, "")
+	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, podcastConfig, "")
 	if err != nil {
 		t.Fatalf("Failed to generate episode transcript: %v", err)
 	}
@@ -84,8 +94,18 @@ func TestCommandExecutionTimeout(t *testing.T) {
 	tempDir := t.TempDir()
 	outputDir := filepath.Join(tempDir, "output")
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// This should complete without hanging (command will timeout but generation continues)
-	err := generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, "")
+	err := generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, podcastConfig, "")
 	if err != nil {
 		t.Fatalf("Episode generation should not fail due to command timeout: %v", err)
 	}

--- a/internal/generate_scanner_test.go
+++ b/internal/generate_scanner_test.go
@@ -44,8 +44,18 @@ func TestGenerateEpisodeWithScanner(t *testing.T) {
 
 	outputDir := filepath.Join(tmpDir, "output")
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// Generate episode transcript (without OpenAI client, so it creates placeholder)
-	err := generateEpisodeTranscript(episode, 1, outputDir, nil, nil, "")
+	err := generateEpisodeTranscript(episode, 1, outputDir, nil, nil, podcastConfig, "")
 	if err != nil {
 		t.Fatalf("generateEpisodeTranscript failed: %v", err)
 	}

--- a/internal/generate_test.go
+++ b/internal/generate_test.go
@@ -99,8 +99,18 @@ func TestGenerateEpisodeTranscript(t *testing.T) {
 	// Create a mock OpenAI client (we'll use nil for now and handle it in the function)
 	outputDir := filepath.Join(".reporadio", "test", "episodes")
 
+	// Create mock podcast config
+	podcastConfig := &PodcastConfig{
+		Title:        "Test Podcast",
+		Description:  "Test Description",
+		Instructions: "Test Instructions",
+		Voicing:      "friendly",
+		Type:         SeriesTypeOnboarding,
+		Episodes:     []Episode{},
+	}
+
 	// Test the function
-	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, "")
+	err = generateEpisodeTranscript(episode, 1, outputDir, nil, []map[string]interface{}{}, podcastConfig, "")
 
 	// For now, we expect this to fail since we don't have a real client
 	// but we want to test the file reading and structure logic


### PR DESCRIPTION
- Consolidated podcast configuration to include series info and episodes.
- Updated tests to use the new PodcastConfig structure.
- Removed redundant episode YAML file creation.
- Added a test script for loading and verifying consolidated podcast config.
- Adjusted generateEpisodeTranscript function to accept PodcastConfig and use fallback values.

Closes #41 