### PR TITLE
feat: add instructions for generating PRDs and managing task lists

### DIFF
--- a/.github/instructions/prd.instructions.md
+++ b/.github/instructions/prd.instructions.md
@@ -1,0 +1,62 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+# Rule: Generating a Product Requirements Document (PRD)
+
+## Goal
+
+To guide an AI assistant in creating a detailed Product Requirements Document (PRD) in Markdown format, based on an initial user prompt. The PRD should be clear, actionable, and suitable for a junior developer to understand and implement the feature.
+
+## Process
+
+1.  **Receive Initial Prompt:** The user provides a brief description or request for a new feature or functionality.
+2.  **Ask Clarifying Questions:** Before writing the PRD, the AI *must* ask clarifying questions to gather sufficient detail. The goal is to understand the "what" and "why" of the feature, not necessarily the "how" (which the developer will figure out).
+3.  **Generate PRD:** Based on the initial prompt and the user's answers to the clarifying questions, generate a PRD using the structure outlined below.
+4.  **Save PRD:** Save the generated document as `prd-[feature-name].md` inside the `agents/prds/` directory.
+
+## Clarifying Questions (Examples)
+
+The AI should adapt its questions based on the prompt, but here are some common areas to explore:
+
+*   **Problem/Goal:** "What problem does this feature solve for the user?" or "What is the main goal we want to achieve with this feature?"
+*   **Target User:** "Who is the primary user of this feature?"
+*   **Core Functionality:** "Can you describe the key actions a user should be able to perform with this feature?"
+*   **User Stories:** "Could you provide a few user stories? (e.g., As a [type of user], I want to [perform an action] so that [benefit].)"
+*   **Acceptance Criteria:** "How will we know when this feature is successfully implemented? What are the key success criteria?"
+*   **Scope/Boundaries:** "Are there any specific things this feature *should not* do (non-goals)?"
+*   **Data Requirements:** "What kind of data does this feature need to display or manipulate?"
+*   **Design/UI:** "Are there any existing design mockups or UI guidelines to follow?" or "Can you describe the desired look and feel?"
+*   **Edge Cases:** "Are there any potential edge cases or error conditions we should consider?"
+
+## PRD Structure
+
+The generated PRD should include the following sections:
+
+1.  **Introduction/Overview:** Briefly describe the feature and the problem it solves. State the goal.
+2.  **Goals:** List the specific, measurable objectives for this feature.
+3.  **User Stories:** Detail the user narratives describing feature usage and benefits.
+4.  **Functional Requirements:** List the specific functionalities the feature must have. Use clear, concise language (e.g., "The system must allow users to upload a profile picture."). Number these requirements.
+5.  **Non-Goals (Out of Scope):** Clearly state what this feature will *not* include to manage scope.
+6.  **Design Considerations (Optional):** Link to mockups, describe UI/UX requirements, or mention relevant components/styles if applicable.
+7.  **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
+8.  **Success Metrics:** How will the success of this feature be measured? (e.g., "Increase user engagement by 10%", "Reduce support tickets related to X").
+9.  **Open Questions:** List any remaining questions or areas needing further clarification.
+
+## Target Audience
+
+Assume the primary reader of the PRD is a **junior developer**. Therefore, requirements should be explicit, unambiguous, and avoid jargon where possible. Provide enough detail for them to understand the feature's purpose and core logic.
+
+## Output
+
+*   **Format:** Markdown (`.md`)
+*   **Location:** `agents/prds/`
+*   **Filename:** `prd-[feature-name].md`
+
+## Final instructions
+
+1. Do NOT start implementing the PRD
+2. Make sure to ask the user clarifying questions
+3. Take the user's answers to the clarifying questions and improve the PRD
+4. Ask the user one question a time until all the questions are answered.

--- a/.github/instructions/task.instructions.md
+++ b/.github/instructions/task.instructions.md
@@ -1,0 +1,37 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# Task List Management
+
+Guidelines for managing task lists in markdown files to track progress on completing a PRD
+
+## Task Implementation
+- **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say "yes" or "y"
+- **Completion protocol:**  
+  1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.  
+  2. If **all** subtasks underneath a parent task are now `[x]`, also mark the **parent task** as completed.  
+- Stop after each sub‑task and wait for the user's go‑ahead.
+
+## Task List Maintenance
+
+1. **Update the task list as you work:**
+   - Mark tasks and subtasks as completed (`[x]`) per the protocol above.
+   - Add new tasks as they emerge.
+
+2. **Maintain the "Relevant Files" section:**
+   - List every file created or modified.
+   - Give each file a one‑line description of its purpose.
+
+## AI Instructions
+
+When working with task lists, the AI must:
+
+1. Regularly update the task list file after finishing any significant work.
+2. Follow the completion protocol:
+   - Mark each finished **sub‑task** `[x]`.
+   - Mark the **parent task** `[x]` once **all** its subtasks are `[x]`.
+3. Add newly discovered tasks.
+4. Keep "Relevant Files" accurate and up to date.
+5. Before starting work, check which sub‑task is next.

--- a/.github/instructions/tasks.instructions.md
+++ b/.github/instructions/tasks.instructions.md
@@ -1,0 +1,130 @@
+# generate-tasks.mdc
+
+## 🌐 Purpose
+
+This macro generates a clear, implementation-agnostic task list based on a Markdown-formatted Product Requirements Document (PRD). The goal is to help teams break down a new feature into logically grouped, actionable units of work without assuming any specific programming language, framework, or platform.
+
+The output is intended to:
+
+* Facilitate planning, backlog grooming, and handoff to developers.
+* Support a junior engineer in understanding what needs to be done.
+* Enable traceability to the original PRD.
+
+This macro assumes the PRD was generated via `create-prd.mdc`.
+
+---
+
+## ✅ What Makes a Good Task
+
+Each task should:
+
+* Start with a verb (e.g., "Define", "Draft", "Review", "Clarify")
+* Describe an action with clear intent
+* Be understandable without technical context
+* Take no more than a day to complete
+* Align with a functional requirement or user story
+* Avoid bundling multiple actions into one task
+
+---
+
+## 🔄 Workflow
+
+1. **Ingest PRD**
+
+   * Parse the PRD Markdown and analyze all sections, especially:
+
+     * Overview
+     * Goals
+     * Functional Requirements
+     * User Stories
+     * Non-Goals
+
+2. **Generate Parent Tasks**
+
+   * Identify major functional components or workflows
+   * Output them as top-level tasks (do not yet break them down)
+   * Pause here unless the `--no-pause` flag is provided
+
+3. **(Optional) Pause for Confirmation**
+
+   * Wait for the user to say "Go" before proceeding to sub-task generation
+   * This supports collaborative refinement of the parent task structure
+
+4. **Generate Sub-Tasks**
+
+   * For each parent task, decompose into specific, atomic actions
+   * Annotate sub-tasks with references to PRD sections for traceability (e.g., `[From: Functional Requirement 2]`)
+
+5. **(Optional) Files to Be Created**
+
+   * If the PRD suggests or implies deliverables (e.g., docs, diagrams), list them and describe their purpose
+   * Do not reference any specific code files, directories, or formats
+
+6. **Output Structure**
+   Format the final output as follows:
+
+```md
+# Task List: [Feature Name]
+
+## Task 1
+- [ ] A  <!-- From: User Story 1 -->
+- [ ] B  <!-- From: Functional Requirement 3 -->
+
+## Task 2
+- [ ] C
+- [ ] D
+
+## Optional: Files to Create
+- `flowchart.md`: captures key user flows from the PRD
+- `acceptance-checklist.md`: tracks criteria from user stories
+```
+
+7. **Save Output**
+
+   * Write to `/tasks/tasks-[feature-name].md`
+
+8. **Prompt for Review**
+
+   * Close by prompting the user to review the task list:
+
+     > "Before continuing, please review this task list for missing assumptions, undefined terms, or ambiguous phrasing. Let me know if you'd like to revise any part."
+
+---
+
+## 🔒 Constraints
+
+* ❌ Do NOT reference specific technologies, programming languages, or tools
+* ❌ Do NOT output file extensions like `.ts`, `.jsx`, `.py`, etc.
+* ✅ Use plain English throughout
+* ✅ Assume the audience includes junior developers
+* ✅ Be unambiguous, neutral, and implementation-agnostic
+
+---
+
+## 🔍 Clarification Phase
+
+Before generating tasks, ask clarifying questions to ensure accuracy and completeness:
+
+1. **Sequential Questions**
+   * Ask one question at a time and wait for the user's response
+   * Focus on areas where the PRD may be ambiguous or incomplete
+   * Target questions that will impact task structure or scope
+
+2. **Question Categories**
+   * **Scope boundaries**: What's explicitly included vs. excluded?
+   * **User personas**: Who are the primary users and what are their contexts?
+   * **Integration points**: How does this feature connect to existing systems?
+   * **Success criteria**: What specific outcomes define completion?
+   * **Assumptions**: What dependencies or prerequisites exist?
+
+3. **Question Format**
+   * Be specific and actionable
+   * Reference relevant PRD sections when asking
+   * Avoid yes/no questions when possible
+
+4. **Completion Criteria**
+   * Continue asking questions until you have sufficient clarity
+   * Confirm understanding before proceeding to task generation
+   * Ask: "Do you have any other clarifications before I generate the task list?"
+
+---


### PR DESCRIPTION
- Introduced guidelines for creating a Product Requirements Document (PRD) in Markdown format, aimed at guiding AI assistants.
- Added a process for managing task lists in markdown files to track progress on completing a PRD.
- Established a macro for generating a clear, implementation-agnostic task list based on a PRD.
- Ensured instructions are suitable for junior developers by avoiding technical jargon and focusing on clarity and completeness.